### PR TITLE
Use alpine instead of debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM frolvlad/alpine-bash
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /wait-for-it.sh
 ENTRYPOINT ["/wait-for-it.sh"]


### PR DESCRIPTION
The image will be smaller, about 10 MB instead of 43 MB today.